### PR TITLE
Add link to actual DevOps page

### DIFF
--- a/ci-cd-faster-easier-development/index.qmd
+++ b/ci-cd-faster-easier-development/index.qmd
@@ -3,7 +3,7 @@
 author:
   - "[Patrick J. Roddy](https://paddyroddy.github.io)"
   - "[DevOps
-    Subgroup](https://www.ucl.ac.uk/advanced-research-computing/our-people-0)"
+    Subgroup](https://www.ucl.ac.uk/advanced-research-computing/collaborations-consultancy/devops-collaborations)"
 date: 2024-09-10
 format: revealjs
 subtitle: "[ARC Collaborations Hour](https://www.ucl.ac.uk/arc)"


### PR DESCRIPTION
Might not work as page isn't public yet. Fixes #69.