### PR TITLE
Disable auto stretch in presentations

### DIFF
--- a/_quarto.yaml
+++ b/_quarto.yaml
@@ -6,6 +6,7 @@ format:
   html:
     theme: darkly
   revealjs:
+    auto-stretch: false
     callout-appearance: simple
     code-copy: true
     filters:


### PR DESCRIPTION
Noticed that talks weren't displaying properly on small screens (i.e. phones). Disabling this setting appears to solve the problem https://quarto.org/docs/presentations/revealjs/advanced.html#stretch.